### PR TITLE
Do not call into xPortSysTickHandler if scheduler is not started

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -75,8 +75,10 @@ void SysTick_Handler(void)
 {
     HAL_IncTick();
     HAL_SYSTICK_IRQHandler();
-
-    xPortSysTickHandler();
+    if (xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED)
+    {
+        xPortSysTickHandler();
+    }
 }
 
 void NMI_Handler(void)


### PR DESCRIPTION
If `HAL_Delay()` is called (so that it waits until the SysTick timer counts up a bit) before `vTaskStartScheduler()` is called, there is a crash (HardFault) during the `xPortSysTickHandler()` call, since `xTaskIncrementTick()` accesses the `pxCurrentTCB` pointer which is a `nullptr`.

I noticed this when using `HAL_Delay()` before the task scheduler startup for a debug LED.

![grafik](https://user-images.githubusercontent.com/26485477/116815456-f07d8c00-ab5d-11eb-97a9-ee7ca428c32f.png)

To spare you headaches from this bug, here is the simple fix :) 

It's the same as [STM32Duino](https://github.com/stm32duino/STM32FreeRTOS/blob/9d9e37ccd89151be9bf0c92d4f5ae3dd7c6c8fba/portable/CMSIS_RTOS/cmsis_os.c#L1362-L1373) does.